### PR TITLE
Fix some typos in source code

### DIFF
--- a/TLSphinx/Decoder.swift
+++ b/TLSphinx/Decoder.swift
@@ -63,7 +63,7 @@ public class Decoder {
         //Sphinx expect words of 2 bytes but the NSFileHandle read one byte at time so the lenght of the data for sphinx is the half of the real one.
         let dataLenght = data.length / 2
         let numberOfFrames = ps_process_raw(psDecoder, UnsafePointer(data.bytes), dataLenght, SFalse, SFalse)
-        let hasSpeech = in_sppech()
+        let hasSpeech = in_speech()
         
         switch (speechState) {
         case .Silence where hasSpeech:
@@ -79,7 +79,7 @@ public class Decoder {
         return numberOfFrames
     }
     
-    private func in_sppech() -> Bool {
+    private func in_speech() -> Bool {
         return ps_get_in_speech(psDecoder) == 1
     }
     

--- a/TLSphinx/Decoder.swift
+++ b/TLSphinx/Decoder.swift
@@ -91,24 +91,24 @@ public class Decoder {
         return ps_end_utt(psDecoder) == 0
     }
     
-    private func get_hyp() -> Hypotesis? {
+    private func get_hyp() -> Hypothesis? {
         var score: CInt = 0
         let string: UnsafePointer<CChar> = ps_get_hyp(psDecoder, &score)
         
         if let text = String.fromCString(string) {
-            return Hypotesis(text: text, score: Int(score))
+            return Hypothesis(text: text, score: Int(score))
         } else {
             return nil
         }
     }
     
-    private func hypotesisForSpeechAtPath (filePath: String) -> Hypotesis? {
+    private func hypotesisForSpeechAtPath (filePath: String) -> Hypothesis? {
         
         if let fileHandle = NSFileHandle(forReadingAtPath: filePath) {
             
             start_utt()
             
-            let hypotesis = fileHandle.reduceChunks(bufferSize, initial: nil, reducer: { (data: NSData, partialHyp: Hypotesis?) -> Hypotesis? in
+            let hypothesis = fileHandle.reduceChunks(bufferSize, initial: nil, reducer: { (data: NSData, partialHyp: Hypothesis?) -> Hypothesis? in
                 
                 self.process_raw(data)
                 
@@ -128,9 +128,9 @@ public class Decoder {
             
             //Process any pending speech
             if speechState == .Speech {
-                return hypotesis + get_hyp()
+                return hypothesis + get_hyp()
             } else {
-                return hypotesis
+                return hypothesis
             }
             
         } else {
@@ -138,19 +138,19 @@ public class Decoder {
         }
     }
     
-    public func decodeSpeechAtPath (filePath: String, complete: (Hypotesis?) -> ()) {
+    public func decodeSpeechAtPath (filePath: String, complete: (Hypothesis?) -> ()) {
         
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
             
-            let hypotesis = self.hypotesisForSpeechAtPath(filePath)
+            let hypothesis = self.hypotesisForSpeechAtPath(filePath)
             
             dispatch_async(dispatch_get_main_queue()) {
-                complete(hypotesis)
+                complete(hypothesis)
             }
         }
     }
     
-    public func startDecodingSpeech (utteranceComplete: (Hypotesis?) -> ()) {
+    public func startDecodingSpeech (utteranceComplete: (Hypothesis?) -> ()) {
         
         let error: NSErrorPointer = nil
         do {

--- a/TLSphinx/Hypotesis.swift
+++ b/TLSphinx/Hypotesis.swift
@@ -1,5 +1,5 @@
 //
-//  Hypotesis.swift
+//  Hypothesis.swift
 //  TLSphinx
 //
 //  Created by Bruno Berisso on 6/1/15.
@@ -8,12 +8,12 @@
 
 import Foundation
 
-public struct Hypotesis {
+public struct Hypothesis {
     public let text: String
     public let score: Int
 }
 
-extension Hypotesis : CustomStringConvertible {
+extension Hypothesis : CustomStringConvertible {
     
     public var description: String {
         get {
@@ -23,11 +23,11 @@ extension Hypotesis : CustomStringConvertible {
     
 }
 
-func +(lhs: Hypotesis, rhs: Hypotesis) -> Hypotesis {
-    return Hypotesis(text: lhs.text + " " + rhs.text, score: (lhs.score + rhs.score) / 2)
+func +(lhs: Hypothesis, rhs: Hypothesis) -> Hypothesis {
+    return Hypothesis(text: lhs.text + " " + rhs.text, score: (lhs.score + rhs.score) / 2)
 }
 
-func +(lhs: Hypotesis?, rhs: Hypotesis?) -> Hypotesis? {
+func +(lhs: Hypothesis?, rhs: Hypothesis?) -> Hypothesis? {
     if let _lhs = lhs, let _rhs = rhs {
         return _lhs + _rhs
     } else {


### PR DESCRIPTION
Fix some typos in source code:

1. Hypotesis -> Hypothesis
2. sppech -> speech