### PR TITLE
Use AVAudioEngine instead of the AVAudioRecorder hack

### DIFF
--- a/TLSphinxTests/LiveDecode.swift
+++ b/TLSphinxTests/LiveDecode.swift
@@ -36,7 +36,7 @@ class LiveDecode: XCTestCase {
                     
                     let expectation = expectationWithDescription("")
                     
-                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(5.0 * Double(NSEC_PER_SEC))) , dispatch_get_main_queue(), { () -> Void in
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(15.0 * Double(NSEC_PER_SEC))) , dispatch_get_main_queue(), { () -> Void in
                         decoder.stopDecodingSpeech()
                         expectation.fulfill()
                     })


### PR DESCRIPTION
This is a trimmed version of [this](https://github.com/tryolabs/TLSphinx/pull/15) pull request to use `AVAudioEngine` for the live decoding instead of the previous method using `AVAudioRecorder`.

This means two direct improvements:
- Don't use an unclear solution like the previous one
- Gain compatibility for OSX, that was the main intention in the original PR